### PR TITLE
chore: do not export unused files/folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,15 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/CHANGELOG.md       export-ignore
+/CONTRIBUTING.md    export-ignore
+/docs               export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
+/.styleci.yml       export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/README.md          export-ignore


### PR DESCRIPTION
This pull request avoids unused files being included on the vendor of the users of this library.