### PR TITLE
Get test suite running on PHP 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,9 +16,6 @@ jobs:
                 laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
-                include:
-                    - laravel: 8.*
-                      testbench: 6.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -35,7 +32,6 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
                 if: "matrix.php < 8"
 
             -   name: Install PHP 8 dependencies
-                run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+                run: composer update --prefer-stable --ignore-platform-req=php --no-interaction --no-progress
                 if: "matrix.php >= 8"
 
             -   name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,8 @@ jobs:
                 php: [8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
+                allow_failures:
+                    - php: 8.0
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
                     coverage: none
                     tools: composer:v2
 
-                -   name: Install PHP 7 dependencies
+            -   name: Install PHP 7 dependencies
                 run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
                 if: "matrix.php < 8"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,9 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none
-            -   name: Install PHP 7 dependencies
+                    tools: composer:v2
+
+                -   name: Install PHP 7 dependencies
                 run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
                 if: "matrix.php < 8"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
                 include:
                     - laravel: 8.*
-                      testbench: 5.*
+                      testbench: 6.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,10 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 7.4, 7.3]
-                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 7.4, 7.3]
-                laravel: [7.*]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2]
+                php: [8.0, 7.4, 7.3, 7.2]
                 laravel: [7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,12 +12,12 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2]
+                php: [8.0, 7.4, 7.3]
                 laravel: [7.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 include:
-                    - laravel: 7.*
+                    - laravel: 8.*
                       testbench: 5.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,12 +28,11 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 
             - name: Install dependencies
               run: |
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                  composer update --${{ matrix.dependency-version }} --no-interaction --no-suggest
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,10 @@
 name: Run tests
 
 on:
-  push:
-  pull_request:
-  schedule:
-      - cron: '0 0 * * *'
+    push:
+    pull_request:
+    schedule:
+        -   cron: '0 0 * * *'
 
 jobs:
     php-tests:
@@ -12,27 +12,30 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3]
-                dependency-version: [prefer-lowest, prefer-stable]
-                os: [ubuntu-latest, windows-latest]
+                php: [ 8.0, 7.4, 7.3 ]
+                dependency-version: [ prefer-lowest, prefer-stable ]
+                os: [ ubuntu-latest, windows-latest ]
                 allow_failures:
-                    - php: 8.0
+                    -   php: 8.0
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+            -   name: Checkout code
+                uses: actions/checkout@v2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  coverage: none
+            -   name: Set up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+            -   name: Install PHP 7 dependencies
+                run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress
+                if: "matrix.php < 8"
 
-            - name: Install dependencies
-              run: |
-                  composer update --${{ matrix.dependency-version }} --no-interaction --no-suggest
+            -   name: Install PHP 8 dependencies
+                run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
+                if: "matrix.php >= 8"
 
-            - name: Execute tests
-              run: vendor/bin/phpunit
+            -   name: Execute tests
+                run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^7.5|^8.0|^9.3.11",
+        "phpunit/phpunit": "^9.3.11",
         "vimeo/psalm": "^3.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
-        "phpunit/phpunit": "^7.5|^8.0",
+        "phpunit/phpunit": "^7.5|^8.0|^9.3.11",
         "vimeo/psalm": "^3.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "php": "^7.3|^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.14",
+        "friendsofphp/php-cs-fixer": "^v2.15.8",
         "phpunit/phpunit": "^9.3.11",
-        "vimeo/psalm": "^3.12"
+        "vimeo/psalm": "^3.17.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Facade Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Facade Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>


### PR DESCRIPTION
This is a leaf node on a little expedition I've been having through laravel packages (starting at ignition), and I've managed to get it to run on PHP 8. Making it run isn't hard because the code is extremely simple, but the dependencies in the test suite were tripping up all over the place. This package has no dependencies, but the test suite pulled in Laravel and testbench, neither of which work on PHP 8 yet, so they broke the build unnecessarily. php-cs-fixer is used for syntax checking, and that's not 8-ready either, however, by switching to composer 2 and disabling platform constraints, it turns out that it's happy to run anyway.

The test config had quite a lot of unnecessary stuff in (e.g. PHP extensions), so I've cut it back quite a lot.

The test suite is a bit too simple, and coverage could be increased very easily, but that's a separate job.